### PR TITLE
Add the ability to watch etcd for changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,9 @@ at a time in this way.
 * ``PYCONFIG_ETCD_CACERT`` - CA cert file to use for SSL
 * ``PYCONFIG_ETCD_CERT`` - Client cert file to use for SSL client authentication  
 * ``PYCONFIG_ETCD_KEY`` - Client private key file to use for SSL client auth 
+* ``PYCONFIG_ETCD_WATCH`` - If this is set to a truthy value (a non-empty
+  string), then pyconfig will keep the local configuration synchronized with
+  etcd
 
 **Inheritance:**
 

--- a/pyconfig/__init__.py
+++ b/pyconfig/__init__.py
@@ -449,7 +449,7 @@ class etcd(object):
 
     def get_watcher(self):
         """
-        Watch the configured prefix for changes.
+        Return a etcd watching generator which yields events as they happen.
 
         """
         if not self.watching:

--- a/pyconfig/__init__.py
+++ b/pyconfig/__init__.py
@@ -456,7 +456,7 @@ class etcd(object):
             raise StopIteration()
         return self.client.eternal_watch(self.prefix, recursive=True)
 
-    def watch(self):
+    def start_watching(self):
         """ Begins watching etcd for changes. """
         # Don't create a new watcher thread if we already have one running
         if self.watcher and self.watcher.is_alive():
@@ -465,14 +465,6 @@ class etcd(object):
         # Create a new watcher thread and start it
         self.watcher = Watcher()
         self.watcher.start()
-
-    def start_watching(self):
-        """
-        Kicks off the watcher.
-
-        """
-        if self.watching:
-            self.watch()
 
     def _parse_hosts(self, hosts):
         """

--- a/pyconfig/__init__.py
+++ b/pyconfig/__init__.py
@@ -80,7 +80,7 @@ class Config(object):
         log.info("    %s = %s", name, repr(value))
 
         # Acquire our lock to change the config
-        with mut_lock:
+        with self.mut_lock:
             self.settings[name] = value
 
     def _update(self, conf_dict, base_name=None):

--- a/test/test_etcd.py
+++ b/test/test_etcd.py
@@ -102,9 +102,6 @@ def test_watching():
     pyconfig.set('pyconfig.etcd.prefix', 'pyconfig_test/watching')
     pyconfig.reload()
 
-    if not pyconfig.etcd().watching:
-        raise SkipTest
-
     # Wait for 20ms before writing to ensure the watcher thread is ready
     time.sleep(0.020)
 

--- a/test/test_etcd.py
+++ b/test/test_etcd.py
@@ -1,3 +1,6 @@
+import os
+import time
+
 import pytool
 from nose import SkipTest
 from nose.tools import ok_, eq_
@@ -31,6 +34,7 @@ def teardown():
     # Clean up the test namespace
     pyconfig.etcd().client.delete('pyconfig_test/test', dir=True, recursive=True)
     pyconfig.etcd().client.delete('pyconfig_test/test2', dir=True, recursive=True)
+    pyconfig.etcd().client.delete('pyconfig_test/watching', dir=True, recursive=True)
     pyconfig.etcd().client.delete('pyconfig_test/', dir=True, recursive=True)
 
 
@@ -88,4 +92,35 @@ def test_autoloading_etcd_config_works():
     pyconfig.reload()
     eq_(pyconfig.get('pyconfig.string'), 'Value')
     eq_(pyconfig.get('pyconfig.number'), 2)
+
+
+def test_watching():
+    # Enable watching
+    os.environ['PYCONFIG_ETCD_WATCH'] = 'true'
+
+    pyconfig.Config().clear()
+    pyconfig.set('pyconfig.etcd.prefix', 'pyconfig_test/watching')
+    pyconfig.reload()
+
+    if not pyconfig.etcd().watching:
+        raise SkipTest
+
+    # Wait for 20ms before writing to ensure the watcher thread is ready
+    time.sleep(0.020)
+
+    # Write a new value directly to etcd
+    pyconfig.etcd().client.write('pyconfig_test/watching/it.works', 
+            pytool.json.as_json(True))
+
+    # Try to get the value... this is a bit sloppy but good luck doing
+    # something better
+    retry = 50
+    while retry:
+        retry -= 1
+        if pyconfig.get('it.works', None) is not None:
+            break
+        # Wait 20ms more for it to show up
+        time.sleep(0.020)
+
+    eq_(pyconfig.get('it.works', False), True)
 


### PR DESCRIPTION
This PR adds the `PYCONFIG_ETCD_WATCH` environment flag which allows pyconfig to watch etcd for changes.